### PR TITLE
removed the nested css altogether and replaced with just #text-group.

### DIFF
--- a/src/styles/index.css
+++ b/src/styles/index.css
@@ -261,7 +261,7 @@ a:focus {
   max-width: 900px;
 }
 
-.hero-heading text {
+#text-group {
   font-family: var(--font-family);
   font-size: 75px;
   font-weight: 900;


### PR DESCRIPTION
Trying to use .hero-heading text did not work in FireFox and using #text-group text did not work in Chrome, so I removed the nesting specificity and just used the #text-group to style it. Worked in both browsers.