### PR TITLE
Use visually-hidden text to disambiguate repeated links and buttons

### DIFF
--- a/src/components/episode-details.js
+++ b/src/components/episode-details.js
@@ -43,7 +43,7 @@ export function EpisodeDetails({ title, teacher, description, url }) {
         <div class="episode-links">
           <a href={url} class="animate">
             <IconInfo /> Episode Details
-			<span class="visually-hidden"> for {title}</span>
+            <span class="visually-hidden"> for {title}</span>
           </a>
           <ShareButton
             title={`${title} (with ${teacher.name})`}

--- a/src/components/episode-details.js
+++ b/src/components/episode-details.js
@@ -43,6 +43,7 @@ export function EpisodeDetails({ title, teacher, description, url }) {
         <div class="episode-links">
           <a href={url} class="animate">
             <IconInfo /> Episode Details
+			<span class="visually-hidden"> for {title}</span>
           </a>
           <ShareButton
             title={`${title} (with ${teacher.name})`}

--- a/src/components/episode-list.js
+++ b/src/components/episode-list.js
@@ -16,6 +16,7 @@ export function EpisodeList({ episodes }) {
           <div class="episode-links top-gradient-border">
             <a href={`/${episode.slug.current}`} class="animate">
               <IconInfo /> Links, Resources, and Transcript
+			  <span class="visually-hidden"> for {episode.title}</span>
             </a>
             <ShareButton
               title={episode.title}

--- a/src/components/episode-list.js
+++ b/src/components/episode-list.js
@@ -16,7 +16,7 @@ export function EpisodeList({ episodes }) {
           <div class="episode-links top-gradient-border">
             <a href={`/${episode.slug.current}`} class="animate">
               <IconInfo /> Links, Resources, and Transcript
-			  <span class="visually-hidden"> for {episode.title}</span>
+	          <span class="visually-hidden"> for {episode.title}</span>
             </a>
             <ShareButton
               title={episode.title}

--- a/src/components/episode-preview.js
+++ b/src/components/episode-preview.js
@@ -45,6 +45,7 @@ export function EpisodePreview({ episode, hideLinks = false, children }) {
               <div class="episode-links">
                 <a href={`/${episode.slug.current}`}>
                   <IconInfo /> Episode Details
+				  <span class="visually-hidden"> for {episode.title}</span>
                 </a>
                 <ShareButton
                   title={episode.title}

--- a/src/components/episode-preview.js
+++ b/src/components/episode-preview.js
@@ -45,7 +45,7 @@ export function EpisodePreview({ episode, hideLinks = false, children }) {
               <div class="episode-links">
                 <a href={`/${episode.slug.current}`}>
                   <IconInfo /> Episode Details
-				  <span class="visually-hidden"> for {episode.title}</span>
+		          <span class="visually-hidden"> for {episode.title}</span>
                 </a>
                 <ShareButton
                   title={episode.title}

--- a/src/components/topic-list.js
+++ b/src/components/topic-list.js
@@ -27,7 +27,7 @@ export function TopicList({ topic, title, episodes }) {
       </ul>
       <div class="topic-links">
         <a href={`/topic/${topic}`}>
-          see more <IconArrow />
+          see more <span class="visually-hidden">from {title}</span><IconArrow />
         </a>
       </div>
     </div>

--- a/src/pages/store.js
+++ b/src/pages/store.js
@@ -109,8 +109,8 @@ export default function Store() {
                   <span class="tag">free shipping!</span>
                 </p>
                 <button aria-label={`Add ${product.name} To Cart`} onClick={addToCart}>
-					Add To Cart
-				</button>
+				  Add To Cart
+			    </button>
               </div>
             );
           })}

--- a/src/pages/store.js
+++ b/src/pages/store.js
@@ -108,7 +108,9 @@ export default function Store() {
                   <span>{formattedPrice}</span>{' '}
                   <span class="tag">free shipping!</span>
                 </p>
-                <button onClick={addToCart}>Add To Cart</button>
+                <button aria-label={`Add ${product.name} To Cart`} onClick={addToCart}>
+					Add To Cart
+				</button>
               </div>
             );
           })}


### PR DESCRIPTION
Howdy! I hope you don't mind me creating a PR for some accessibility stuff! Specifically, I noticed that there were several lists with repeated links and buttons. For instance, `TopicList` has a bunch of "See more" links. Some screenreader users prefer to navigate pages quickly by skipping from link to link, and that can make repeated links like this kind of confusing. I used `.visually-hidden` to disambiguate each of these links. I also used `aria-label`s on the store's Add To Cart buttons to make it a little clearer what you were adding to your cart.

Please let me know if you have any questions, comments, or feedback!