### PR TITLE
fix: opt-in-form input text color

### DIFF
--- a/sites/blog/src/components/opt-in-form.module.css
+++ b/sites/blog/src/components/opt-in-form.module.css
@@ -46,7 +46,7 @@
 	background: var(--color-white);
 	border: 1px solid var(--color-text-default);
 	border-radius: 0.25rem;
-	color: var(--text);
+	color: var(--color-gray-text);
 	padding: 0.5rem;
 	width: 100%;
 }


### PR DESCRIPTION
The subscribe form inputs text color is white. It appears the CSS custom property of `var(--text)` isn't defined in the CSS, perhaps a legacy property?

I've changed it to `var(--color-gray-text)` from your design-system as it appears other css properties are using them. 

See attached screen recording for issue.

https://share.cleanshot.com/zkFTJRnVsfmGt1DPm41c