### PR TITLE
a11y: remove unecessary aria-label from buttons

### DIFF
--- a/sites/blog/src/pages/store.astro
+++ b/sites/blog/src/pages/store.astro
@@ -58,7 +58,7 @@ const products: Products = await response.json();
 							{/* TODO: make this into a quantity selector */}
 							<input type="hidden" name="quantity" value={1} />
 
-							<Button aria-label="Add To Cart" class="button">
+							<Button class="button">
 								Add <span class="visually-hidden">{product.title}</span> To Cart
 							</Button>
 						</form>

--- a/sites/www/app/routes/store.jsx
+++ b/sites/www/app/routes/store.jsx
@@ -200,7 +200,7 @@ export default function Store() {
 									/>
 									{/* TODO: make this into a quantity selector */}
 									<input type="hidden" name="quantity" value={1} />
-									<button aria-label={`Add To Cart`}>
+									<button>
 										Add <span className="visually-hidden">{product.title}</span>{' '}
 										To Cart
 									</button>


### PR DESCRIPTION
- Removes aria-label from the "Add to Cart" buttons in the store. The inner label already has that context (and adds the product title using `visually-hidden` text). 

## Before video


https://user-images.githubusercontent.com/30670444/217692718-3828eb7a-7ca2-4ba0-9730-fa7001f1674c.mp4 

(Video alt: The store on the blog site with NVDA reading each button in the store as "add to cart" as they are focused with the `tab` button)


## After video

https://user-images.githubusercontent.com/30670444/217693522-e61f9990-7af3-444e-aec2-3bc024b6eed5.mp4

(Video alt: The store on the blog site with NVDA reading "Add 'title of product' to cart", where 'title of product' is the title of the product in the list as they are focused with the tab button). 
