### PR TITLE
fix(css): fix legacy browsers (css nesting support)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2926,6 +2926,27 @@
 				"node": ">=6.9.0"
 			}
 		},
+		"node_modules/@csstools/selector-specificity": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-3.0.0.tgz",
+			"integrity": "sha512-hBI9tfBtuPIi885ZsZ32IMEU/5nlZH/KOVYJCOh7gyMxaVLGmLedYqFN6Ui1LXkI8JlC8IsuC0rF0btcRZKd5g==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss-selector-parser": "^6.0.13"
+			}
+		},
 		"node_modules/@emmetio/abbreviation": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/@emmetio/abbreviation/-/abbreviation-2.3.3.tgz",
@@ -33405,7 +33426,33 @@
 			"dependencies": {
 				"@astrojs/check": "^0.3.1",
 				"astro": "^3.5.3",
+				"postcss-nesting": "^12.0.1",
 				"typescript": "^5.2.2"
+			}
+		},
+		"sites/partners/node_modules/postcss-nesting": {
+			"version": "12.0.1",
+			"resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-12.0.1.tgz",
+			"integrity": "sha512-6LCqCWP9pqwXw/njMvNK0hGY44Fxc4B2EsGbn6xDcxbNRzP8GYoxT7yabVVMLrX3quqOJ9hg2jYMsnkedOf8pA==",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/csstools"
+				},
+				{
+					"type": "opencollective",
+					"url": "https://opencollective.com/csstools"
+				}
+			],
+			"dependencies": {
+				"@csstools/selector-specificity": "^3.0.0",
+				"postcss-selector-parser": "^6.0.13"
+			},
+			"engines": {
+				"node": "^14 || ^16 || >=18"
+			},
+			"peerDependencies": {
+				"postcss": "^8.4"
 			}
 		},
 		"sites/scenes": {

--- a/sites/partners/package.json
+++ b/sites/partners/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@astrojs/check": "^0.3.1",
     "astro": "^3.5.3",
+    "postcss-nesting": "^12.0.1",
     "typescript": "^5.2.2"
   }
 }

--- a/sites/partners/postcss.config.cjs
+++ b/sites/partners/postcss.config.cjs
@@ -1,0 +1,5 @@
+module.exports = {
+    plugins: [
+      require('postcss-nesting')
+    ],
+  };


### PR DESCRIPTION
By adding a PostCSS config file (with the `postcss-nesting` plugin) I was able to fix the CSS nesting issue that was causing legacy browsers to look Ugly!

Before:
![image](https://github.com/learnwithjason/learnwithjason.dev/assets/725120/1c0d4004-d94a-4c4d-b611-16baf65e7e5b)


After
<img width="1728" alt="Screenshot 2023-11-22 at 00 08 47" src="https://github.com/learnwithjason/learnwithjason.dev/assets/725120/45d3a459-7e46-47d0-b01b-19773d831b99">
