### PR TITLE
Remove text at bottom of schedule page

### DIFF
--- a/sites/www/src/pages/schedule.astro
+++ b/sites/www/src/pages/schedule.astro
@@ -141,4 +141,4 @@ const lede =
 			grid-template-columns: repeat(auto-fit, min(calc(50% - 1.5rem), 600px));
 		}
 	}
-</style>../components/episode-preview.solid
+</style>


### PR DESCRIPTION
Hey @jlengstorf,

just stumbled upon a text below your footer on your schedule page which shouldn't be there, I suppose.

![Screenshot_20240116-171526](https://github.com/learnwithjason/learnwithjason.dev/assets/18489354/9b863855-9c26-4a8d-be4d-868577ace741)

You probably accidentally copied and pasted the file path into the Astro file below the style block.

Thought I could just quickly create a PR to fix it.

Thank you, and keep up with your great work and content! :)

Greetings from Germany!

BTW: feel free to close this PR if it's easier for you to just go into the file and change it yourself. Thought before I bother with sending an email or something like that, I would just create a PR.